### PR TITLE
Add cardano node socket path to env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: cardano-node-testnet
     environment:
       NETWORK: preprod
+      CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
     volumes:
       - ./preprod-configs:/config/preprod
       - node-testnet-db:/data


### PR DESCRIPTION
Добавил чтобы не было ошибки когда подключаешься к контейнеру:
```bash
 % docker exec -ti cardano-node-testnet bash
bash-5.1# cardano-cli query tip --testnet-magic 1
Command failed: query tip  Error: Error while looking up environment variable: CARDANO_NODE_SOCKET_PATH  Error: "CARDANO_NODE_SOCKET_PATH"
```